### PR TITLE
Fix code scanning alert no. 12: Code injection

### DIFF
--- a/fixtures/dom/src/react-loader.js
+++ b/fixtures/dom/src/react-loader.js
@@ -65,7 +65,11 @@ function loadModules(SymbolSrcPairs) {
 
 function getVersion() {
   let query = parseQuery(window.location.search);
-  return query.version || 'local';
+  let version = query.version || 'local';
+  if (version !== 'local' && !semver.valid(version)) {
+    throw new Error('Invalid version parameter');
+  }
+  return version;
 }
 
 export function reactPaths(version = getVersion()) {


### PR DESCRIPTION
Fixes [https://github.com/akadev1/react/security/code-scanning/12](https://github.com/akadev1/react/security/code-scanning/12)

To fix the problem, we need to ensure that the `version` parameter is validated and sanitized before it is used to construct URLs and script content. We can use a regular expression to validate that the `version` parameter follows the expected format of a semantic version (e.g., `15.4.1`). If the `version` parameter does not match the expected format, we should reject it or use a default safe value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
